### PR TITLE
feat: add R2I and GEM_PIX models, runImageRecipe API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # whisk-api
 
 Unofficial free reverse engineered API for Google's Whisk from [labs.google](https://labs.google).
@@ -15,12 +14,21 @@ bun i -g @rohitaryal/whisk-api
 
 ## Features
 
-1. Text to Image using `IMAGEN_3_5`
-2. Image to Video (Animation) using `VEO`
-3. Image Refinement (Editing/Inpainting using NanoBanana)
-4. Image to Text
-5. Project & Media Management
-6. Command line support
+1. Text to Image using `R2I` or `GEM_PIX` models
+2. Image Recipe - Combine multiple images (subject, scene, style)
+3. Image Refinement (Edit images with AI)
+4. Image to Video (Animation) using `VEO_3_1`
+5. Image to Text (Caption generation)
+6. Project & Media Management
+7. Command line support
+
+## Models
+
+| Model | Type | Use Case |
+|-------|------|----------|
+| `R2I` | Image | Text-to-image, multi-image recipes (default) |
+| `GEM_PIX` | Image | Text-to-image, image refinement |
+| `VEO_3_1` | Video | Image-to-video animation |
 
 ## Usage
 
@@ -66,14 +74,21 @@ Make sure you have:
 
     ```bash
     # saves generated image at ./output/ by default
-    whisk generate --prompt "A bad friend" --cookie "$COOKIE"
+    whisk generate --prompt "A futuristic city" --cookie "$COOKIE"
+    ```
+
+- Selecting a specific model
+
+    ```bash
+    # Available: R2I (default), GEM_PIX
+    whisk generate --prompt "A beautiful sunset" --model "GEM_PIX" --cookie "$COOKIE"
     ```
 
 - Selecting a specific aspect ratio
 
     ```bash
     # Available: SQUARE, PORTRAIT, LANDSCAPE (Default: LANDSCAPE)
-    whisk generate --prompt "Reptillian CEO" --aspect "PORTRAIT" --cookie "$COOKIE"
+    whisk generate --prompt "Portrait of a warrior" --aspect "PORTRAIT" --cookie "$COOKIE"
     ```
 
 - Animating an existing image (Image to Video)
@@ -86,7 +101,7 @@ Make sure you have:
 - Refining (Editing) an image
 
     ```bash
-    whisk refine "__MEDIA__ID__HERE__" --prompt "Add a red hat to the character" --cookie "$COOKIE"
+    whisk refine "__MEDIA__ID__HERE__" --prompt "Add a red hat" --cookie "$COOKIE"
     ```
 
 - Generating caption from a local image file
@@ -110,7 +125,7 @@ Options:
       --version     Show version number
   -h, --help        Show help
   -p, --prompt      Description of the image
-  -m, --model       Image generation model (Default: IMAGEN_3_5)
+  -m, --model       Image model (R2I, GEM_PIX) - Default: R2I
   -a, --aspect      Aspect ratio (SQUARE, PORTRAIT, LANDSCAPE)
   -s, --seed        Seed value (0 for random)
   -d, --dir         Output directory
@@ -127,22 +142,9 @@ Positionals:
 
 Options:
   -s, --script    Prompt/Script for the video animation
-  -m, --model     Video generation model (Default: VEO_FAST_3_1)
+  -m, --model     Video generation model (Default: VEO_3_1)
   -d, --dir       Output directory
   -c, --cookie    Google account cookie
-```
-
-Full fetch help:
-
-```text
-whisk fetch <mediaId>
-
-Positionals:
-  mediaId  Unique ID of generated media
-
-Options:
-  -d, --dir      Output directory
-  -c, --cookie   Google account cookie
 ```
 
 </details>
@@ -150,49 +152,191 @@ Options:
 <details>
 <summary style="font-weight: bold;font-size:15px;">Importing as module</summary>
 
-- Basic image generation
+### Basic Image Generation
 
-    ```typescript
-    import { Whisk } from "@rohitaryal/whisk-api";
+```typescript
+import { Whisk } from "@rohitaryal/whisk-api";
 
-    const whisk = new Whisk(process.env.COOKIE);
+const whisk = new Whisk(process.env.COOKIE);
 
-    // 1. Create a project context
-    const project = await whisk.newProject("My Project");
+// 1. Create a project context
+const project = await whisk.newProject("My Project");
 
-    // 2. Generate image
-    const media = await project.generateImage("A big black cockroach");
-    
-    // 3. Save to disk
-    const savedPath = media.save("./output");
-    console.log("[+] Image saved at: " + savedPath);
-    ```
+// 2. Generate image (uses R2I by default)
+const media = await project.generateImage("A futuristic city skyline");
 
-- Advanced Workflow (Gen -> Refine -> Animate)
+// 3. Save to disk
+const savedPath = media.save("./output");
+console.log("Image saved at: " + savedPath);
+```
 
-    ```typescript
-    import { Whisk, ImageAspectRatio } from "@rohitaryal/whisk-api";
+### Generate with Model Selection
 
-    const whisk = new Whisk(process.env.COOKIE);
-    const project = await whisk.newProject("Video Workflow");
+```typescript
+import { Whisk } from "@rohitaryal/whisk-api";
 
-    // 1. Generate Base Image (Must be LANDSCAPE for video)
-    const baseImage = await project.generateImage({
-        prompt: "A cybernetic city",
-        aspectRatio: "IMAGE_ASPECT_RATIO_LANDSCAPE"
-    });
+const whisk = new Whisk(process.env.COOKIE);
+const project = await whisk.newProject("My Project");
 
-    // 2. Refine (Edit)
-    const refinedImage = await baseImage.refine("Make it raining neon rain");
+// Generate with specific model
+const image = await project.generateImage({
+    prompt: "A serene mountain landscape",
+    model: "GEM_PIX",  // or "R2I"
+    aspectRatio: "IMAGE_ASPECT_RATIO_LANDSCAPE"
+});
 
-    // 3. Animate (Video)
-    const video = await refinedImage.animate("Camera flies through the streets", "VEO_FAST_3_1");
+image.save("./output");
+```
 
-    video.save("./videos");
-    ```
+### Image Recipe (Multi-Image Composition)
+
+Combine multiple images using subject, scene, and style:
+
+```typescript
+import { Whisk, MediaCategory } from "@rohitaryal/whisk-api";
+
+const whisk = new Whisk(process.env.COOKIE);
+const project = await whisk.newProject("Recipe Project");
+
+// Generate source images
+const subjectImg = await project.generateImage("A golden crown");
+const sceneImg = await project.generateImage("A mystical forest");
+const styleImg = await project.generateImage("Cyberpunk neon aesthetic");
+
+// Run image recipe to combine them
+const result = await project.runImageRecipe({
+    userInstruction: "Place the crown in the forest with cyberpunk lighting",
+    subject: {
+        caption: subjectImg.prompt,
+        mediaGenerationId: subjectImg.mediaGenerationId,
+        category: MediaCategory.SUBJECT
+    },
+    scene: {
+        caption: sceneImg.prompt,
+        mediaGenerationId: sceneImg.mediaGenerationId,
+        category: MediaCategory.SCENE
+    },
+    style: {
+        caption: styleImg.prompt,
+        mediaGenerationId: styleImg.mediaGenerationId,
+        category: MediaCategory.STYLE
+    }
+});
+
+result.save("./output");
+```
+
+### Image Refinement
+
+```typescript
+import { Whisk } from "@rohitaryal/whisk-api";
+
+const whisk = new Whisk(process.env.COOKIE);
+const project = await whisk.newProject("Refine Project");
+
+// Generate base image
+const baseImage = await project.generateImage("A portrait of a warrior");
+
+// Refine with default model (GEM_PIX)
+const refined = await baseImage.refine("Add golden armor");
+
+// Or specify model
+const refinedR2I = await baseImage.refine("Add a red cape", "R2I");
+
+refined.save("./output");
+```
+
+### Advanced Workflow (Generate -> Refine -> Animate)
+
+```typescript
+import { Whisk } from "@rohitaryal/whisk-api";
+
+const whisk = new Whisk(process.env.COOKIE);
+const project = await whisk.newProject("Video Workflow");
+
+// 1. Generate Base Image (Must be LANDSCAPE for video)
+const baseImage = await project.generateImage({
+    prompt: "A cybernetic city at night",
+    model: "R2I",
+    aspectRatio: "IMAGE_ASPECT_RATIO_LANDSCAPE"
+});
+
+// 2. Refine (Edit)
+const refinedImage = await baseImage.refine("Add neon rain falling");
+
+// 3. Animate (Video)
+const video = await refinedImage.animate(
+    "Camera slowly flies through the streets, rain falling",
+    "VEO_3_1_I2V_12STEP"
+);
+
+video.save("./videos");
+```
+
+### Caption Generation
+
+```typescript
+import { Whisk } from "@rohitaryal/whisk-api";
+
+const whisk = new Whisk(process.env.COOKIE);
+const project = await whisk.newProject("Caption Project");
+
+const image = await project.generateImage("A sunset over the ocean");
+
+// Generate captions
+const captions = await image.caption(3);
+console.log("Captions:", captions);
+```
 
 More examples are at: [/examples](https://github.com/rohitaryal/imageFX-api/tree/main/examples)
 </details>
+
+## API Reference
+
+### Classes
+
+| Class | Description |
+|-------|-------------|
+| `Whisk` | Main entry point, manages account and creates projects |
+| `Project` | Project context for generating images and running recipes |
+| `Media` | Generated media with methods for refine, animate, caption, save |
+| `Account` | Session management (internal) |
+
+### Key Methods
+
+| Method | Description |
+|--------|-------------|
+| `whisk.newProject(name)` | Create a new project |
+| `project.generateImage(prompt)` | Generate image from text |
+| `project.runImageRecipe(config)` | Combine subject/scene/style images |
+| `media.refine(prompt, model?)` | Edit/refine an image |
+| `media.animate(script, model?)` | Convert image to video |
+| `media.caption(count?)` | Generate captions for image |
+| `media.save(directory?)` | Save media to disk |
+| `media.deleteMedia()` | Delete from cloud |
+
+### Constants
+
+```typescript
+import { ImageModel, VideoGenerationModel, ImageAspectRatio, MediaCategory } from "@rohitaryal/whisk-api";
+
+// Image Models
+ImageModel.R2I           // "R2I"
+ImageModel.GEM_PIX       // "GEM_PIX"
+
+// Video Models
+VideoGenerationModel.VEO_3_1  // "VEO_3_1_I2V_12STEP"
+
+// Aspect Ratios
+ImageAspectRatio.SQUARE      // "IMAGE_ASPECT_RATIO_SQUARE"
+ImageAspectRatio.PORTRAIT    // "IMAGE_ASPECT_RATIO_PORTRAIT"
+ImageAspectRatio.LANDSCAPE   // "IMAGE_ASPECT_RATIO_LANDSCAPE"
+
+// Media Categories (for recipes)
+MediaCategory.SUBJECT   // "MEDIA_CATEGORY_SUBJECT"
+MediaCategory.SCENE     // "MEDIA_CATEGORY_SCENE"
+MediaCategory.STYLE     // "MEDIA_CATEGORY_STYLE"
+```
 
 ## Help
 
@@ -219,7 +363,7 @@ More examples are at: [/examples](https://github.com/rohitaryal/imageFX-api/tree
 </details>
 
 <details>
-<summary style="font-weight: bold;font-size:15px;">ImageFX not available in your country?</summary>
+<summary style="font-weight: bold;font-size:15px;">Whisk not available in your country?</summary>
 
 1. Install a free VPN (Windscribe, Proton, etc)
 2. Open [labs.google](https://labs.google/fx/tools/whisk/project) and login
@@ -236,7 +380,7 @@ Create an issue [here](https://github.com/rohitaryal/imageFX-api/issues). Make s
 
 ## Contributions
 
-Contribution are welcome but ensure to pass all test cases and follow existing coding standard.
+Contributions are welcome but ensure to pass all test cases and follow existing coding standard.
 
 ## Disclaimer
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,72 +1,252 @@
 {
-  "name": "@rohitaryal/whisk-api",
-  "version": "1.0.2",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "@rohitaryal/whisk-api",
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "bun-types": "^1.2.14",
-        "undici-types": "^6.21.0"
-      },
-      "devDependencies": {
-        "@types/bun": "latest",
-        "typescript": "^5.8.3"
-      },
-      "peerDependencies": {
-        "typescript": "^5"
-      }
-    },
-    "node_modules/@types/bun": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.2.15.tgz",
-      "integrity": "sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bun-types": "1.2.15"
-      }
-    },
-    "node_modules/@types/node": {
-      "version": "22.15.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
-      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/bun-types": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.2.15.tgz",
-      "integrity": "sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "license": "MIT"
+    "name": "@rohitaryal/whisk-api",
+    "version": "3.0.1",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@rohitaryal/whisk-api",
+            "version": "3.0.1",
+            "license": "MIT",
+            "dependencies": {
+                "bun-types": "^1.2.14",
+                "undici-types": "^6.21.0",
+                "yargs": "^18.0.0"
+            },
+            "bin": {
+                "whisk": "dist/Cli.js"
+            },
+            "devDependencies": {
+                "@types/bun": "^1.3.5",
+                "@types/yargs": "^17.0.35",
+                "typescript": "^5.8.3"
+            },
+            "peerDependencies": {
+                "typescript": "^5"
+            }
+        },
+        "node_modules/@types/bun": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.5.tgz",
+            "integrity": "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bun-types": "1.3.5"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "22.15.29",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
+            "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
+        },
+        "node_modules/@types/yargs": {
+            "version": "17.0.35",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+            "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/yargs-parser": "*"
+            }
+        },
+        "node_modules/@types/yargs-parser": {
+            "version": "21.0.3",
+            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+            "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/bun-types": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.5.tgz",
+            "integrity": "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+            "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^7.2.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "license": "MIT"
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-east-asian-width": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+            "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "license": "MIT"
+        },
+        "node_modules/wrap-ansi": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs": {
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+            "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^9.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "string-width": "^7.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^22.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+            "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        }
     }
-  }
 }

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -5,7 +5,7 @@ import { Whisk } from "./Whisk.js";
 import { imageToBase64 } from "./Utils.js";
 import {
     ImageAspectRatio,
-    ImageGenerationModel,
+    ImageModel,
     VideoGenerationModel
 } from "./Constants.js";
 
@@ -17,7 +17,7 @@ await y
     .command(
         "generate",
         "Generate new images using a temporary project",
-        (yargs) => {
+        (yargs: any) => {
             return yargs
                 .option("prompt", {
                     alias: "p",
@@ -29,8 +29,8 @@ await y
                     alias: "m",
                     describe: "Image generation model",
                     type: "string",
-                    default: "IMAGEN_3_5",
-                    choices: Object.keys(ImageGenerationModel)
+                    default: "R2I",
+                    choices: Object.keys(ImageModel)
                 })
                 .option("aspect", {
                     alias: "a",
@@ -58,7 +58,7 @@ await y
                     demandOption: true,
                 })
         },
-        async (argv) => {
+        async (argv: any) => {
             const whisk = new Whisk(argv.cookie);
             await whisk.account.refresh();
             console.log(whisk.account.toString());
@@ -76,7 +76,7 @@ await y
 
                 const media = await project.generateImage({
                     prompt: argv.prompt,
-                    model: ImageGenerationModel[argv.model as keyof typeof ImageGenerationModel],
+                    model: ImageModel[argv.model as keyof typeof ImageModel],
                     aspectRatio: aspectVal,
                     seed: argv.seed
                 });
@@ -94,7 +94,7 @@ await y
     .command(
         "animate <mediaId>",
         "Animate an existing landscape image into a video",
-        (yargs) => {
+        (yargs: any) => {
             return yargs
                 .positional("mediaId", {
                     describe: "The ID of the image to animate",
@@ -111,7 +111,7 @@ await y
                     alias: "m",
                     describe: "Video generation model",
                     type: "string",
-                    default: "VEO_FAST_3_1",
+                    default: "VEO_3_1",
                     choices: Object.keys(VideoGenerationModel)
                 })
                 .option("dir", {
@@ -127,7 +127,7 @@ await y
                     demandOption: true,
                 })
         },
-        async (argv) => {
+        async (argv: any) => {
             const whisk = new Whisk(argv.cookie);
             await whisk.account.refresh();
             console.log(whisk.account.toString());
@@ -156,7 +156,7 @@ await y
     .command(
         "refine <mediaId>",
         "Edit/Refine an existing image",
-        (yargs) => {
+        (yargs: any) => {
             return yargs
                 .positional("mediaId", {
                     describe: "The ID of the image to refine",
@@ -168,6 +168,13 @@ await y
                     describe: "Instruction for editing (e.g., 'Make it snowy')",
                     type: "string",
                     demandOption: true
+                })
+                .option("model", {
+                    alias: "m",
+                    describe: "Image model for refinement",
+                    type: "string",
+                    default: "GEM_PIX",
+                    choices: Object.keys(ImageModel)
                 })
                 .option("dir", {
                     alias: "d",
@@ -182,7 +189,7 @@ await y
                     demandOption: true,
                 })
         },
-        async (argv) => {
+        async (argv: any) => {
             const whisk = new Whisk(argv.cookie);
             await whisk.account.refresh();
             console.log(whisk.account.toString());
@@ -193,7 +200,10 @@ await y
                 const originalMedia = await Whisk.getMedia(argv.mediaId, whisk.account);
 
                 console.log("[*] Refining image...");
-                const refinedMedia = await originalMedia.refine(argv.prompt);
+                const refinedMedia = await originalMedia.refine(
+                    argv.prompt,
+                    ImageModel[argv.model as keyof typeof ImageModel]
+                );
 
                 const savedPath = refinedMedia.save(argv.dir);
                 console.log(`[+] Image refined successfully!`);
@@ -207,7 +217,7 @@ await y
     .command(
         "caption",
         "Generate captions for a local image file",
-        (yargs) => {
+        (yargs: any) => {
             return yargs
                 .option("file", {
                     alias: "f",
@@ -228,7 +238,7 @@ await y
                     demandOption: true,
                 })
         },
-        async (argv) => {
+        async (argv: any) => {
             const whisk = new Whisk(argv.cookie);
             await whisk.account.refresh();
             console.log(whisk.account.toString());
@@ -244,7 +254,7 @@ await y
                 const captions = await Whisk.generateCaption(rawBase64, whisk.account, argv.count);
 
                 console.log("\n--- Captions ---");
-                captions.forEach((cap, i) => {
+                captions.forEach((cap: string, i: number) => {
                     console.log(`[${i + 1}] ${cap}`);
                 });
 
@@ -256,7 +266,7 @@ await y
     .command(
         "fetch <mediaId>",
         "Download an existing generated media by ID",
-        (yargs) => {
+        (yargs: any) => {
             return yargs
                 .positional("mediaId", {
                     describe: "Unique ID of generated media",
@@ -276,7 +286,7 @@ await y
                     demandOption: true,
                 })
         },
-        async (argv) => {
+        async (argv: any) => {
             const whisk = new Whisk(argv.cookie);
             await whisk.account.refresh();
             console.log(whisk.account.toString());
@@ -295,7 +305,7 @@ await y
     .command(
         "delete <mediaId>",
         "Delete a generated media from the cloud",
-        (yargs) => {
+        (yargs: any) => {
             return yargs
                 .positional("mediaId", {
                     describe: "Unique ID of generated media to delete",
@@ -309,7 +319,7 @@ await y
                     demandOption: true,
                 })
         },
-        async (argv) => {
+        async (argv: any) => {
             const whisk = new Whisk(argv.cookie);
             await whisk.account.refresh();
             console.log(whisk.account.toString());

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -28,15 +28,18 @@ export const VideoAspectRatio = Object.freeze({
     UNSPECIFIED: "VIDEO_ASPECT_RATIO_UNSPECIFIED",
 } as const);
 
-export const ImageGenerationModel = Object.freeze({
-    IMAGEN_3_5: "IMAGEN_3_5",
-} as const);
-
-export const ImageRefinementModel = Object.freeze({
+export const ImageModel = Object.freeze({
+    R2I: "R2I",
     GEM_PIX: "GEM_PIX",
-});
+} as const);
 
 export const VideoGenerationModel = Object.freeze({
     VEO_3_1: "VEO_3_1_I2V_12STEP",
-    VEO_FAST_3_1: "veo_3_1_i2v_s_fast",
+} as const);
+
+export const MediaCategory = Object.freeze({
+    SUBJECT: "MEDIA_CATEGORY_SUBJECT",
+    SCENE: "MEDIA_CATEGORY_SCENE",
+    STYLE: "MEDIA_CATEGORY_STYLE",
+    BOARD: "MEDIA_CATEGORY_BOARD",
 } as const);

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -1,6 +1,6 @@
-import { ImageGenerationModel } from "./Constants.js";
+import { ImageModel, MediaCategory } from "./Constants.js";
 import { Media } from "./Media.js";
-import type { ImageGenerationModelType, PromptConfig } from "./Types.js";
+import type { ImageModelType, PromptConfig, RecipeConfig } from "./Types.js";
 import { request } from "./Utils.js";
 import { Account } from "./Whisk.js";
 
@@ -21,23 +21,29 @@ export class Project {
         this.account = account;
     }
 
+    /**
+     * Generate an image from a text prompt
+     *
+     * @param input Text prompt or PromptConfig object
+     * @returns Generated Media object
+     */
     async generateImage(input: string | PromptConfig): Promise<Media> {
         if (typeof input === "string") {
             input = {
                 seed: 0,
                 prompt: input,
-                model: "IMAGEN_3_5",
+                model: "R2I",
                 aspectRatio: "IMAGE_ASPECT_RATIO_LANDSCAPE"
             } as PromptConfig;
         }
 
         if (!input.seed) input.seed = 0;
-        if (!input.model) input.model = "IMAGEN_3_5";
+        if (!input.model) input.model = "R2I";
         if (!input.aspectRatio) input.aspectRatio = "IMAGE_ASPECT_RATIO_LANDSCAPE";
         if (!input.prompt?.trim?.()) throw new Error("prompt is required");
 
-        if (!Object.values(ImageGenerationModel).includes(input.model as ImageGenerationModelType)) {
-            throw new Error(`'${input.model}': invalid image generation model provided`)
+        if (!Object.values(ImageModel).includes(input.model as ImageModelType)) {
+            throw new Error(`'${input.model}': invalid image model. Use 'R2I' or 'GEM_PIX'`)
         }
 
         const generationResponse = await request<any>(
@@ -73,8 +79,98 @@ export class Project {
     }
 
     /**
-    * Deletes the project, clearance of your slop from the existance
-    */
+     * Run an image recipe combining multiple images (subject, scene, style)
+     * Uses the R2I model to blend images based on user instruction
+     *
+     * @param config Recipe configuration with subject (required), scene, and style images
+     * @returns Generated Media object
+     */
+    async runImageRecipe(config: RecipeConfig): Promise<Media> {
+        if (!config.userInstruction?.trim?.()) {
+            throw new Error("userInstruction is required");
+        }
+
+        if (!config.subject) {
+            throw new Error("subject is required");
+        }
+
+        const recipeMediaInputs: Array<{
+            caption: string;
+            mediaInput: {
+                mediaCategory: string;
+                mediaGenerationId: string;
+            };
+        }> = [
+            {
+                caption: config.subject.caption,
+                mediaInput: {
+                    mediaCategory: MediaCategory.SUBJECT,
+                    mediaGenerationId: config.subject.mediaGenerationId
+                }
+            }
+        ];
+
+        if (config.scene) {
+            recipeMediaInputs.push({
+                caption: config.scene.caption,
+                mediaInput: {
+                    mediaCategory: MediaCategory.SCENE,
+                    mediaGenerationId: config.scene.mediaGenerationId
+                }
+            });
+        }
+
+        if (config.style) {
+            recipeMediaInputs.push({
+                caption: config.style.caption,
+                mediaInput: {
+                    mediaCategory: MediaCategory.STYLE,
+                    mediaGenerationId: config.style.mediaGenerationId
+                }
+            });
+        }
+
+        const recipeResponse = await request<any>(
+            "https://aisandbox-pa.googleapis.com/v1/whisk:runImageRecipe",
+            {
+                headers: {
+                    authorization: `Bearer ${await this.account.getToken()}`
+                },
+                body: JSON.stringify({
+                    clientContext: {
+                        workflowId: this.projectId,
+                        tool: "BACKBONE",
+                        sessionId: `;${Date.now()}`
+                    },
+                    seed: config.seed ?? Math.floor(Math.random() * 1000000),
+                    imageModelSettings: {
+                        imageModel: "R2I",
+                        aspectRatio: config.aspectRatio ?? "IMAGE_ASPECT_RATIO_LANDSCAPE"
+                    },
+                    userInstruction: config.userInstruction,
+                    recipeMediaInputs
+                })
+            }
+        );
+
+        const img = recipeResponse.imagePanels[0].generatedImages[0];
+
+        return new Media({
+            seed: img.seed,
+            prompt: img.prompt,
+            workflowId: img.workflowId ?? recipeResponse.workflowId,
+            encodedMedia: img.encodedImage,
+            mediaGenerationId: img.mediaGenerationId,
+            aspectRatio: img.aspectRatio,
+            mediaType: "IMAGE",
+            model: img.imageModel,
+            account: this.account
+        });
+    }
+
+    /**
+     * Deletes the project
+     */
     async delete() {
         await request(
             "https://labs.google/fx/api/trpc/media.deleteMedia",

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1,5 +1,5 @@
 import type { Account } from "./Whisk.js";
-import { ImageAspectRatio, VideoAspectRatio, ImageExtension, ImageGenerationModel, VideoGenerationModel, ImageRefinementModel } from "./Constants.js";
+import { ImageAspectRatio, VideoAspectRatio, ImageExtension, ImageModel, VideoGenerationModel, MediaCategory } from "./Constants.js";
 
 export interface MediaConfig {
     seed: number;
@@ -10,20 +10,35 @@ export interface MediaConfig {
     mediaGenerationId: string;
     mediaType: "VIDEO" | "IMAGE";
     aspectRatio: ImageAspectRatioType | VideoAspectRatioType;
-    model: ImageGenerationModelType | VideoGenerationModelType;
+    model: ImageModelType | VideoGenerationModelType;
     account: Account;
 }
 
 export interface PromptConfig {
     seed?: number;
     prompt: string;
-    aspectRatio?: ImageAspectRatioType | VideoAspectRatioType;
-    model?: ImageGenerationModelType | VideoGenerationModelType;
+    aspectRatio?: ImageAspectRatioType;
+    model?: ImageModelType;
+}
+
+export interface RecipeMediaInput {
+    caption: string;
+    mediaGenerationId: string;
+    category: MediaCategoryType;
+}
+
+export interface RecipeConfig {
+    seed?: number;
+    userInstruction: string;
+    aspectRatio?: ImageAspectRatioType;
+    subject: RecipeMediaInput;
+    scene?: RecipeMediaInput;
+    style?: RecipeMediaInput;
 }
 
 export type ImageAspectRatioType = typeof ImageAspectRatio[keyof typeof ImageAspectRatio];
 export type VideoAspectRatioType = typeof VideoAspectRatio[keyof typeof VideoAspectRatio];
 export type ImageExtensionTypes = typeof ImageExtension[keyof typeof ImageExtension];
-export type ImageGenerationModelType = typeof ImageGenerationModel[keyof typeof ImageGenerationModel];
+export type ImageModelType = typeof ImageModel[keyof typeof ImageModel];
 export type VideoGenerationModelType = typeof VideoGenerationModel[keyof typeof VideoGenerationModel];
-export type ImageRefinementModelType = typeof ImageRefinementModel[keyof typeof ImageRefinementModel];
+export type MediaCategoryType = typeof MediaCategory[keyof typeof MediaCategory];

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export { Whisk } from "./Whisk.js";
 export { Media } from "./Media.js";
 export { Project } from "./Project.js";
 export * from "./Types.js";
+export * from "./Constants.js";


### PR DESCRIPTION
## Summary

- Replace IMAGEN_3_5 with **R2I** as default image generation model
- Add **GEM_PIX** as alternative model for generation and refinement
- Add `runImageRecipe()` for multi-image composition (subject/scene/style)
- Allow model selection in `generateImage()` and `refine()` methods
- Update CLI with new model options and defaults
- Add `MediaCategory` constants for recipe inputs
- Update documentation with new API reference

## New Features

### Image Models
| Model | Use Case |
|-------|----------|
| `R2I` | Text-to-image, multi-image recipes (default) |
| `GEM_PIX` | Text-to-image, image refinement |

### runImageRecipe API
Combine multiple images (subject, scene, style) using the R2I model:

```typescript
const result = await project.runImageRecipe({
    userInstruction: "combine the crown in the forest with cyberpunk lighting",
    subject: { caption, mediaGenerationId, category: MediaCategory.SUBJECT },
    scene: { caption, mediaGenerationId, category: MediaCategory.SCENE },
    style: { caption, mediaGenerationId, category: MediaCategory.STYLE }
});
```

### Model Selection
```typescript
// Generate with specific model
await project.generateImage({ prompt: "...", model: "GEM_PIX" });

// Refine with specific model  
await image.refine("edit instruction", "R2I");
```

## Test plan
- [x] Build passes
- [ ] Test text-to-image with R2I model
- [ ] Test text-to-image with GEM_PIX model
- [ ] Test runImageRecipe with subject/scene/style
- [ ] Test image refinement with model selection
- [ ] Test CLI commands with new defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)