### PR TITLE
exposed public API for util

### DIFF
--- a/examples/9-custom-image-reference.ts
+++ b/examples/9-custom-image-reference.ts
@@ -7,7 +7,8 @@ async function main() {
 
     // let add 2 characters as subject (caption + upload handled automatically)
     console.log("Uploading local image as subject...")
-    await project.addSubject({ file: "./assets/patrick.png" })
+    const patrick = await project.addSubject({ file: "./assets/patrick.png" })
+    console.log(patrick.mediaGenerationId, patrick.prompt);
     await project.addSubject({ file: "./assets/spongebob.png" })
 
     // can also use a URL directly

--- a/examples/9-custom-image-reference.ts
+++ b/examples/9-custom-image-reference.ts
@@ -1,5 +1,4 @@
 import { Whisk } from "../src/Whisk";
-import { imageToBase64, imageFromUrl } from "../src/Utils";
 
 const whisk = new Whisk(process.env.COOKIE!);
 
@@ -8,19 +7,15 @@ async function main() {
 
     // let add 2 characters as subject (caption + upload handled automatically)
     console.log("Uploading local image as subject...")
-    const SubjectBase64 = await imageToBase64("./assets/patrick.png");
-    const Subject1Base64 = await imageToBase64("./assets/spongebob.png");
-    await project.addSubject(SubjectBase64)
-    await project.addSubject(Subject1Base64)
+    await project.addSubject({ file: "./assets/patrick.png" })
+    await project.addSubject({ file: "./assets/spongebob.png" })
 
-    // can also use imageFromUrl
+    // can also use a URL directly
     console.log("Uploading URL image as scene...")
-    const SceneBase64 = await imageToBase64("./assets/gym-scene.jpg");
-    await project.addScene(SceneBase64)
+    await project.addScene({ file: "./assets/gym-scene.jpg" })
 
     console.log("Uploading URL image as style...")
-    const StyleBase64 = await imageToBase64("./assets/style-ghibli.jpg");
-    await project.addStyle(StyleBase64)
+    await project.addStyle({ file: "./assets/style-ghibli.jpg" })
 
     console.log("Generating final image with custom references...")
     const generatedImage = await project.generateImageWithReferences("working out in the gym")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rohitaryal/whisk-api",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -1,7 +1,7 @@
 import { ImageGenerationModel, MediaCategory } from "./Constants.js";
 import { Media } from "./Media.js";
-import type { ImageGenerationModelType, MediaCategoryType, MediaReference, PromptConfig } from "./Types.js";
-import { request } from "./Utils.js";
+import type { ImageGenerationModelType, ImageInput, MediaCategoryType, MediaReference, PromptConfig } from "./Types.js";
+import { request, resolveImageInput } from "./Utils.js";
 import { Account, Whisk } from "./Whisk.js";
 
 export class Project {
@@ -30,31 +30,33 @@ export class Project {
     /**
      * Uploads a custom image and adds it as a subject reference
      *
-     * @param rawBytes Base64 encoded image (with or without data URI prefix)
+     * @param input Image as { file: string }, { url: string }, or { base64: string }
      */
-    async addSubject(rawBytes: string): Promise<void> {
-        await this.addReference(rawBytes, MediaCategory.SUBJECT, this.subjects);
+    async addSubject(input: ImageInput): Promise<void> {
+        await this.addReference(input, MediaCategory.SUBJECT, this.subjects);
     }
 
     /**
      * Uploads a custom image and adds it as a scene reference
      *
-     * @param rawBytes Base64 encoded image (with or without data URI prefix)
+     * @param input Image as { file: string }, { url: string }, or { base64: string }
      */
-    async addScene(rawBytes: string): Promise<void> {
-        await this.addReference(rawBytes, MediaCategory.SCENE, this.scenes);
+    async addScene(input: ImageInput): Promise<void> {
+        await this.addReference(input, MediaCategory.SCENE, this.scenes);
     }
 
     /**
      * Uploads a custom image and adds it as a style reference
      *
-     * @param rawBytes Base64 encoded image (with or without data URI prefix)
+     * @param input Image as { file: string }, { url: string }, or { base64: string }
      */
-    async addStyle(rawBytes: string): Promise<void> {
-        await this.addReference(rawBytes, MediaCategory.STYLE, this.styles);
+    async addStyle(input: ImageInput): Promise<void> {
+        await this.addReference(input, MediaCategory.STYLE, this.styles);
     }
 
-    private async addReference(rawBytes: string, category: MediaCategoryType, target: MediaReference[]): Promise<void> {
+    private async addReference(input: ImageInput, category: MediaCategoryType, target: MediaReference[]): Promise<void> {
+        const rawBytes = await resolveImageInput(input);
+
         if (!(rawBytes?.trim?.())) {
             throw new Error("image data is required")
         }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -33,3 +33,8 @@ export interface MediaReference {
     prompt: string;
     mediaGenerationId: string;
 }
+
+export type ImageInput =
+    | { file: string }
+    | { url: string }
+    | { base64: string }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,5 @@ export { Whisk } from "./Whisk.js";
 export { Media } from "./Media.js";
 export { Project } from "./Project.js";
 export * from "./Types.js";
+export * from "./Constants.js";
 export { imageToBase64, imageFromUrl } from "./Utils.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export { Whisk } from "./Whisk.js";
 export { Media } from "./Media.js";
 export { Project } from "./Project.js";
 export * from "./Types.js";
+export { imageToBase64, imageFromUrl } from "./Utils.js";


### PR DESCRIPTION
This is Follow up on #14 . When I added `addSubject`, `addScene`, and `addStyle`,
they only accepted raw base64 strings. Once I started actually using them,
I realized every call needed a conversion step first:

```ts
const base64 = await imageToBase64("./cat.png");
await project.addSubject(base64);
```

That gets old fast, especially when you're adding multiple references.
The methods should just handle this internally.

Now they accept a typed `ImageInput` object:

```ts
await project.addSubject({ file: "./cat.png" })
await project.addScene({ url: "https://example.com/bg.jpg" })
await project.addStyle({ base64: rawBytes })
```

The object key makes it obvious what you're passing in, and the library
does the conversion for you.

 I also fixed two things:

- `imageToBase64` had an optional `imageType` param that was never needed
  since it already infers the type from the file extension. Removed it.
- `imageFromUrl` was silently falling back to `image/png` when the server
  didn't return a content-type. Now it validates against `ImageExtension`
  the same way `imageToBase64` does.

`imageToBase64` and `imageFromUrl` are still exported as general purpose
utilities. They're not required for any of the library's main workflows
anymore, but they're handy to have if you need base64 conversion


## Changes

- `src/Types.ts` - added `ImageInput` type
- `src/Utils.ts` - added `resolveImageInput()`, dropped `imageType` param,
  added content-type validation to `imageFromUrl`
- `src/Project.ts` - `addSubject/addScene/addStyle` now take `ImageInput`
- `examples/9-custom-image-reference.ts` - updated to use new API